### PR TITLE
Amend Docker file to reference .jar and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-alpine
 
 VOLUME /tmp
-ADD build/libs/laa-nolasa-0.0.1-SNAPSHOT.war app.war
+ADD build/libs/nolasa-0.1.0.jar app.jar
 
-ENTRYPOINT ["java","-jar","app.war"]
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ git clone {this repo}
 cd laa-nolasa
 ./gradlew clean build
 ```
-The 'nolasa.war' is available at:
+The 'nolasa-0.1.0.jar' is available at:
 ```./build/libs```
+
+Build docker image:
+```docker build -t nolasa```
+
+run docker image:
+``` docker run nolasa ```
+
 
 ## Deployment
 TODO: Mian


### PR DESCRIPTION
Amends Dockerfile to reflect the move to `.jar` artifact rather than `.war`. 

Amends README to reflect `.jar` artifact adds line on running tests and AWS deployment.  