### PR TITLE
LASB-66 - Updated to prevent status update when status is RESULTS REJ…

### DIFF
--- a/src/main/java/com/laa/nolasa/laanolasa/service/InfoXServiceClient.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/service/InfoXServiceClient.java
@@ -15,6 +15,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.GregorianCalendar;
 
 @Service
@@ -75,6 +76,7 @@ public class InfoXServiceClient {
                 for (int i = 0; (i < libraSearchResponse.getSearchResultItem().size() && i < MAX_LIBRA_RECORDS); i++) {
                     result[i] = Long.valueOf(libraSearchResponse.getSearchResultItem().get(i).getCaseResult().get(0).getCaseDetail().getLibraCaseId());
                 }
+                Arrays.sort(result);
                 return new InfoXSearchResult(result, InfoXSearchStatus.SUCCESS);
             case "999999":
                 return new InfoXSearchResult(result, InfoXSearchStatus.FAILURE);

--- a/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
@@ -13,7 +13,7 @@ import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.laa.nolasa.laanolasa.util.LibraUtil.isLibraIDsEqual;
+import static com.laa.nolasa.laanolasa.util.LibraUtil.areLibraIDsEqual;
 import static com.laa.nolasa.laanolasa.util.LibraUtil.updateLibraDetails;
 
 @Service
@@ -41,7 +41,7 @@ public class ReconciliationService {
 
             if (InfoXSearchStatus.FAILURE == infoXSearchResult.getStatus()) {
                 log.debug("No matching record returned by infoX service for MAATID {}", entity.getRepOrders().getId());
-            } else if (NolStatuses.RESULTS_REJECTED.valueOf().equals(entity.getStatus()) && isLibraIDsEqual(entity.getRepOrders().getNolAutoSearchResults(), infoXSearchResult.getLibraIDs())) {
+            } else if (NolStatuses.RESULTS_REJECTED.valueOf().equals(entity.getStatus()) && areLibraIDsEqual(entity.getRepOrders().getNolAutoSearchResults(), infoXSearchResult.getLibraIDs())) {
                 log.info("No changes were detected in libra IDs corresponding to the MAAT ID {} ", entity.getRepOrders().getId());
             } else {
                 updateNol(entity, infoXSearchResult);

--- a/src/main/java/com/laa/nolasa/laanolasa/util/LibraUtil.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/util/LibraUtil.java
@@ -2,6 +2,8 @@ package com.laa.nolasa.laanolasa.util;
 
 import com.laa.nolasa.laanolasa.entity.NolAutoSearchResults;
 
+import java.util.Arrays;
+
 public class LibraUtil {
 
     private static final String COLON = ":";
@@ -9,6 +11,7 @@ public class LibraUtil {
 
     public static void updateLibraDetails(NolAutoSearchResults autoSearchResult, Long[] libraIDs) {
 
+        Arrays.sort(libraIDs);
         autoSearchResult.setLibrId1(libraIDs[0]);
         autoSearchResult.setLibrId2(libraIDs[1]);
         autoSearchResult.setLibrId3(libraIDs[2]);
@@ -26,7 +29,7 @@ public class LibraUtil {
         autoSearchResult.setLibrId15(libraIDs[14]);
     }
 
-    public static boolean isLibraIDsEqual(NolAutoSearchResults nolAutoSearchResults, Long[] libraIDs) {
+    public static boolean areLibraIDsEqual(NolAutoSearchResults nolAutoSearchResults, Long[] libraIDs) {
         return stringifyLibraIDs(nolAutoSearchResults).equals(stringifyLibraIDs(libraIDs));
     }
 

--- a/src/test/java/com/laa/nolasa/laanolasa/service/ReconciliationServiceTest.java
+++ b/src/test/java/com/laa/nolasa/laanolasa/service/ReconciliationServiceTest.java
@@ -40,22 +40,7 @@ public class ReconciliationServiceTest {
 
         List<Nol> nols = new ArrayList<Nol>();
 
-        NolAutoSearchResults autoSearch1 = new NolAutoSearchResults();
-        autoSearch1.setLibrId1(1L);
-        autoSearch1.setLibrId2(2L);
-        autoSearch1.setLibrId3(3L);
-        autoSearch1.setLibrId4(4L);
-        autoSearch1.setLibrId5(5L);
-        autoSearch1.setLibrId6(6L);
-        autoSearch1.setLibrId7(7L);
-        autoSearch1.setLibrId8(8L);
-        autoSearch1.setLibrId9(9L);
-        autoSearch1.setLibrId10(10L);
-        autoSearch1.setLibrId11(11L);
-        autoSearch1.setLibrId12(12L);
-        autoSearch1.setLibrId13(13L);
-        autoSearch1.setLibrId14(14L);
-        autoSearch1.setLibrId15(15L);
+        NolAutoSearchResults autoSearch1 = getNolAutoSearchResults(0L);
 
         RepOrders repoOrder1 = new RepOrders();
         repoOrder1.setId(901L);
@@ -63,24 +48,9 @@ public class ReconciliationServiceTest {
 
         Nol nol1 = new Nol();
         nol1.setRepOrders(repoOrder1);
-        nol1.setStatus( NolStatuses.RESULTS_REJECTED.valueOf());
+        nol1.setStatus(NolStatuses.RESULTS_REJECTED.valueOf());
 
-        NolAutoSearchResults autoSearch2 = new NolAutoSearchResults();
-        autoSearch2.setLibrId1(21L);
-        autoSearch2.setLibrId2(22L);
-        autoSearch2.setLibrId3(23L);
-        autoSearch2.setLibrId4(24L);
-        autoSearch2.setLibrId5(25L);
-        autoSearch2.setLibrId6(26L);
-        autoSearch2.setLibrId7(27L);
-        autoSearch2.setLibrId8(28L);
-        autoSearch2.setLibrId9(29L);
-        autoSearch2.setLibrId10(210L);
-        autoSearch2.setLibrId11(211L);
-        autoSearch2.setLibrId12(212L);
-        autoSearch2.setLibrId13(213L);
-        autoSearch2.setLibrId14(214L);
-        autoSearch2.setLibrId15(215L);
+        NolAutoSearchResults autoSearch2 = getNolAutoSearchResults(20L);
 
         RepOrders repoOrder2 = new RepOrders();
         repoOrder2.setId(920L);
@@ -100,42 +70,13 @@ public class ReconciliationServiceTest {
 
         when(nolRepository.getNolForAutoSearch(NolStatuses.NOT_ON_LIBRA.valueOf(), NolStatuses.LETTER_SENT.valueOf(), NolStatuses.RESULTS_REJECTED.valueOf())).thenReturn(nols);
 
-        Long[] libraIDs1 = new Long[15];
-        libraIDs1[0] = 1L;
-        libraIDs1[1] = 2L;
-        libraIDs1[2] = 3L;
-        libraIDs1[3] = 4L;
-        libraIDs1[4] = 5L;
-        libraIDs1[5] = 6L;
-        libraIDs1[6] = 7L;
-        libraIDs1[7] = 8L;
-        libraIDs1[8] = 9L;
-        libraIDs1[9] = 10L;
-        libraIDs1[10] = 11L;
-        libraIDs1[11] = 12L;
-        libraIDs1[12] = 13L;
-        libraIDs1[13] = 14L;
-        libraIDs1[14] = 15L;
+        Long[] libraIDs1 = getLibraIds(0L);
 
         InfoXSearchStatus status1 = InfoXSearchStatus.SUCCESS;
         InfoXSearchResult infoXSearchResult1 = new InfoXSearchResult(libraIDs1, status1);
 
-        Long[] libraIDs2 = new Long[15];
-        libraIDs2[0] = 31L;
-        libraIDs2[1] = 32L;
-        libraIDs2[2] = 33L;
-        libraIDs2[3] = 34L;
-        libraIDs2[4] = 35L;
-        libraIDs2[5] = 36L;
-        libraIDs2[6] = 37L;
-        libraIDs2[7] = 38L;
-        libraIDs2[8] = 39L;
-        libraIDs2[9] = 310L;
-        libraIDs2[10] = 311L;
-        libraIDs2[11] = 312L;
-        libraIDs2[12] = 313L;
-        libraIDs2[13] = 314L;
-        libraIDs2[14] = 315L;
+        Long[] libraIDs2 = getLibraIds(30L);
+
 
         InfoXSearchStatus status2 = InfoXSearchStatus.SUCCESS;
         InfoXSearchResult infoXSearchResult2 = new InfoXSearchResult(libraIDs2, status2);
@@ -153,4 +94,118 @@ public class ReconciliationServiceTest {
         verify(nolRepository).save(nol2);
         verify(nolRepository, never()).save(nol1);
     }
+
+
+    @Test
+    public void shouldNotProcessRejectedResultsWhenLibraIdsMatch() {
+
+        List<Nol> nols = new ArrayList<Nol>();
+
+        NolAutoSearchResults autoSearch1 = getNolAutoSearchResults(0L);
+
+        RepOrders repoOrder1 = new RepOrders();
+        repoOrder1.setId(901L);
+        repoOrder1.setNolAutoSearchResults(autoSearch1);
+
+        Nol nol1 = new Nol();
+        nol1.setRepOrders(repoOrder1);
+        nol1.setStatus(NolStatuses.RESULTS_REJECTED.valueOf());
+
+
+        nols.add(nol1);
+
+        when(nolRepository.getNolForAutoSearch(NolStatuses.NOT_ON_LIBRA.valueOf(), NolStatuses.LETTER_SENT.valueOf(), NolStatuses.RESULTS_REJECTED.valueOf())).thenReturn(nols);
+
+        Long[] libraIDs1 = getLibraIds(0L);
+
+        InfoXSearchStatus status1 = InfoXSearchStatus.SUCCESS;
+        InfoXSearchResult infoXSearchResult1 = new InfoXSearchResult(libraIDs1, status1);
+
+
+        when(infoXServiceClient.search(any(Nol.class))).thenReturn(infoXSearchResult1);
+
+        reconciliationService.reconcile();
+
+        verify(nolRepository).getNolForAutoSearch(NolStatuses.NOT_ON_LIBRA.valueOf(), NolStatuses.LETTER_SENT.valueOf(), NolStatuses.RESULTS_REJECTED.valueOf());
+        verify(infoXServiceClient).search(nol1);
+        verify(nolRepository, never()).save(nol1);
+    }
+
+    @Test
+    public void shoulProcessRejectedResultsWhenLibraIdsDoNotMatch() {
+
+        List<Nol> nols = new ArrayList<Nol>();
+
+        NolAutoSearchResults autoSearch1 = getNolAutoSearchResults(0L);
+
+        RepOrders repoOrder1 = new RepOrders();
+        repoOrder1.setId(901L);
+        repoOrder1.setNolAutoSearchResults(autoSearch1);
+
+        Nol nol1 = new Nol();
+        nol1.setRepOrders(repoOrder1);
+        nol1.setStatus(NolStatuses.RESULTS_REJECTED.valueOf());
+
+
+        nols.add(nol1);
+
+        when(nolRepository.getNolForAutoSearch(NolStatuses.NOT_ON_LIBRA.valueOf(), NolStatuses.LETTER_SENT.valueOf(), NolStatuses.RESULTS_REJECTED.valueOf())).thenReturn(nols);
+
+        Long[] libraIDs1 = getLibraIds(0L);
+
+        libraIDs1[10] = 16L;
+
+        InfoXSearchStatus status1 = InfoXSearchStatus.SUCCESS;
+        InfoXSearchResult infoXSearchResult1 = new InfoXSearchResult(libraIDs1, status1);
+
+
+        when(infoXServiceClient.search(any(Nol.class))).thenReturn(infoXSearchResult1);
+
+        reconciliationService.reconcile();
+
+        verify(nolRepository).getNolForAutoSearch(NolStatuses.NOT_ON_LIBRA.valueOf(), NolStatuses.LETTER_SENT.valueOf(), NolStatuses.RESULTS_REJECTED.valueOf());
+        verify(infoXServiceClient).search(nol1);
+        verify(nolRepository).save(nol1);
+    }
+
+    private NolAutoSearchResults getNolAutoSearchResults(Long startValue) {
+        NolAutoSearchResults autoSearch1 = new NolAutoSearchResults();
+        autoSearch1.setLibrId1(startValue + 1L);
+        autoSearch1.setLibrId2(startValue + 2L);
+        autoSearch1.setLibrId3(startValue + 3L);
+        autoSearch1.setLibrId4(startValue + 4L);
+        autoSearch1.setLibrId5(startValue + 5L);
+        autoSearch1.setLibrId6(startValue + 6L);
+        autoSearch1.setLibrId7(startValue + 7L);
+        autoSearch1.setLibrId8(startValue + 8L);
+        autoSearch1.setLibrId9(startValue + 9L);
+        autoSearch1.setLibrId10(startValue + 10L);
+        autoSearch1.setLibrId11(startValue + 11L);
+        autoSearch1.setLibrId12(startValue + 12L);
+        autoSearch1.setLibrId13(startValue + 13L);
+        autoSearch1.setLibrId14(startValue + 14L);
+        autoSearch1.setLibrId15(startValue + 15L);
+        return autoSearch1;
+    }
+
+    private Long[] getLibraIds(Long startValue) {
+        Long[] libraIDs1 = new Long[15];
+        libraIDs1[0] = startValue + 1L;
+        libraIDs1[1] = startValue + 2L;
+        libraIDs1[2] = startValue + 3L;
+        libraIDs1[3] = startValue + 4L;
+        libraIDs1[4] = startValue + 5L;
+        libraIDs1[5] = startValue + 6L;
+        libraIDs1[6] = startValue + 7L;
+        libraIDs1[7] = startValue + 8L;
+        libraIDs1[8] = startValue + 9L;
+        libraIDs1[9] = startValue + 10L;
+        libraIDs1[10] = startValue + 11L;
+        libraIDs1[11] = startValue + 12L;
+        libraIDs1[12] = startValue + 13L;
+        libraIDs1[13] = startValue + 14L;
+        libraIDs1[14] = startValue + 15L;
+        return libraIDs1;
+    }
+
 }


### PR DESCRIPTION
…ECTED

Application was unnecessarily including NOT ON LIBRA to see if previous id's were same. In reality this would never happen as NOT ON LIBRA would not have the id's. However, this impacts test as test reuse the same id to rerun the test.