### PR TITLE
Enabling aws xray integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile name: 'ojdbc8'
     compileOnly "org.projectlombok:lombok"
     testCompile('org.springframework.boot:spring-boot-starter-test')
-    compile 'com.amazonaws:aws-xray-recorder-sdk-spring:2.1.0'
+    compile 'com.amazonaws:aws-xray-recorder-sdk-spring:1.3.1'
     compile 'org.aspectj:aspectjrt:1.9.2'
     compile(files(genJaxb.classesDir).builtBy(genJaxb))
     jaxb "com.sun.xml.bind:jaxb-xjc:2.1.7"

--- a/src/main/java/com/laa/nolasa/laanolasa/scheduler/OncePerDayScheduler.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/scheduler/OncePerDayScheduler.java
@@ -1,5 +1,6 @@
 package com.laa.nolasa.laanolasa.scheduler;
 
+import com.amazonaws.xray.AWSXRay;
 import com.laa.nolasa.laanolasa.service.ReconciliationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,7 +18,9 @@ public class OncePerDayScheduler {
 
     @Scheduled(cron = "${app.cron.string}")
     public void reconcile() {
+        AWSXRay.beginSegment("Scorekeep-init");
         reconciliationService.reconcile();
+        AWSXRay.endSegment();
     }
 
 }

--- a/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
@@ -1,5 +1,6 @@
 package com.laa.nolasa.laanolasa.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import com.laa.nolasa.laanolasa.common.NolStatuses;
 import com.laa.nolasa.laanolasa.dto.InfoXSearchResult;
 import com.laa.nolasa.laanolasa.dto.InfoXSearchStatus;
@@ -19,7 +20,7 @@ import static com.laa.nolasa.laanolasa.util.LibraUtil.updateLibraDetails;
 
 @Service
 @Slf4j
-//@XRayEnabled
+@XRayEnabled
 public class ReconciliationService {
 
     @Value("${app.dry-run-mode}")


### PR DESCRIPTION
We are using aws-xray-recorder-sdk-spring, https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-aop-spring.html . It is straight forward for web applications and should not require any java custom code. However, NOLASA, being scheduler only, does not recieve any HTTP request so the default behaviour of starting a segment automatically does not work. We had to add code to begin and end segment in the scheduler.

The following debug snippet from the local docker-compose app shows that xray is emtting the required info:

app_1  | 2019-01-28 12:13:00.336 DEBUG 1 --- [pool-1-thread-1] com.amazonaws.xray.emitters.UDPEmitter   : {
app_1  |   "name" : "Scorekeep-init",
app_1  |   "id" : "14e364ff8f22dd42",
app_1  |   "start_time" : 1.548677579936E9,
app_1  |   "trace_id" : "1-5c4ef1cb-4ac26372ca41df529e0768a3",
app_1  |   "end_time" : 1.548677580335E9,
app_1  |   "subsegments" : [ {
app_1  |     "name" : "reconcile",
app_1  |     "id" : "3da07ea62bf53af7",
app_1  |     "start_time" : 1.548677579973E9,
app_1  |     "end_time" : 1.548677580198E9,
app_1  |     "metadata" : {
app_1  |       "ClassInfo" : {
app_1  |         "Class" : "ReconciliationService"
app_1  |       }
app_1  |     }
app_1  |   } ],
app_1  |   "aws" : {
app_1  |     "xray" : {
app_1  |       "sdk_version" : "1.3.1",
app_1  |       "sdk" : "X-Ray for Java"
app_1  |     }
app_1  |   },
app_1  |   "service" : {
app_1  |     "runtime" : "OpenJDK 64-Bit Server VM",
app_1  |     "runtime_version" : "1.8.0_171"
app_1  |   }
app_1  | }