### PR TITLE
Disable stack name detection if metrics are disabled

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,6 @@ cloud:
   aws:
     region:
       static: eu-west-2
+
+    stack:
+      auto: ${CLOUDWATCH_EXPORT_ENABLED}


### PR DESCRIPTION
Currently we get an error saying the user is `not authorized to perform: cloudformation:DescribeStackResources`

I think this is because spring cloud tries to discover the stack name itself if running on AWS.

It can be disabled by setting `auto` to false. This will allow us to roll out the cloudformation changes one environment at a time.

http://cloud.spring.io/spring-cloud-aws/spring-cloud-aws.html#_cloudformation_configuration_in_spring_boot