### PR TITLE
Enable cloudwatch export on test

### DIFF
--- a/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
@@ -13,7 +13,8 @@
     "pLibraEndPointURI": "http://infox.aws.tst.legalservices.gov.uk/infoX/gateway",
     "pSev5SnsTopicArn": "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn": "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
-    "pSev1SnsTopicArn": "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic"
+    "pSev1SnsTopicArn": "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
+    "pCloudWatchExportEnabled": true
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,4 +56,4 @@ cloud:
       static: eu-west-2
 
     stack:
-      auto: ${CLOUDWATCH_EXPORT_ENABLED}
+      auto: false


### PR DESCRIPTION
This probably won't work.

In order for this to work the app needs to be able to pick up credentials https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html

And the role the app takes on needs the right permissions to be able to talk to cloudwatch.

From looking at the cloud formation it seems like:

- The ECS Autoscaling group is linked to a launch configuration
- The launch config is linked to an IamInstanceProfile
- The IamInstanceProfile is linked to a role with the app-ecs-service policy
- I don't know if this is inherited by the task/container

Meanwhile there is another `${pAppName}-ecs-service` policy that seems to be unused. I think this deals with load balancing and is not available to the application itself.

I *think* what I need to define is a task role:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

For now, I just want to try running the app on test with the exporter enabled, to see what the library complains about. I'll roll this back at the end of the day if I don't figure it out.
