### PR TITLE
Add missing parameter definition

### DIFF
--- a/aws/application/app-main.template
+++ b/aws/application/app-main.template
@@ -75,6 +75,13 @@ Parameters:
     Description: ARN of Sev5 SNS topic for alerting
     Type: String
     Default: ''
+  pCloudWatchExportEnabled:
+    Type: String
+    Default: false
+    AllowedValues:
+        - true
+        - false
+    Description: Enable export of application metrics to Cloudwatch
 
 Resources:
   AppInfrastructureTemplate:
@@ -107,6 +114,7 @@ Resources:
         pDataSourceUname: !Ref pDataSourceUname
         pDataSourcePwd: !Ref pDataSourcePwd
         pDataSourceUrl: !Ref pDataSourceUrl
+        pCloudWatchExportEnabled: !Ref pCloudWatchExportEnabled
 
   MonitoringTemplate:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
The parameter was defined in the application_stack template, but
was missing from the app-main template that includes it.