### PR TITLE
Grant AppEc2Role permission to create metrics

### DIFF
--- a/aws/application/infrastructure_stack.template
+++ b/aws/application/infrastructure_stack.template
@@ -86,6 +86,7 @@ Resources:
               - 'logs:CreateLogStream'
               - 'logs:PutLogEvents'
               - 'ecr:*'
+              - 'cloudwatch:PutMetricData'
             Resource: '*'
 
   CloudwatchLogsGroupEC2:


### PR DESCRIPTION
The application is using this role to export metrics.
Currently it errors due to this permission being missing.