### PR TITLE
Add application metrics to the dashboard

### DIFF
--- a/aws/application/monitoring_stack.template
+++ b/aws/application/monitoring_stack.template
@@ -167,9 +167,40 @@ Resources:
         {
           "widgets" : [
             {
+                "type": "metric",
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 6,
+                "properties": {
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "metrics": [
+                        [ "nolasa", "reconciliation.successful", "statistic", "count" ]
+                    ],
+                    "region": "${AWS::Region}",
+                    "title": "Number of NOL cases successfully processed"
+                }
+            },
+            {
+                "type": "metric",
+                "x": 12,
+                "y": 0,
+                "width": 12,
+                "height": 6,
+                "properties": {
+                    "view": "singleValue",
+                    "metrics": [
+                        [ "nolasa", "reconciliation.numberOfResults.avg" ]
+                    ],
+                    "region": "${AWS::Region}",
+                    "title": "Average number of results returned by autosearch queries"
+                }
+            },
+            {
               "type" : "metric",
               "x" : 0,
-              "y" : 12,
+              "y" : 6,
               "width" : 12,
               "height" : 6,
               "properties" : {
@@ -187,7 +218,7 @@ Resources:
             {
               "type" : "metric",
               "x" : 12,
-              "y" : 12,
+              "y" : 6,
               "width" : 12,
               "height" : 6,
               "properties" : {


### PR DESCRIPTION
We currently have a dashboard with CPU and memory information on it.
This adds some application metrics that are captured by micrometer.

This is not particularly useful at the moment, but I want to make
sure I can create the dashboard programatically before finalising the
metrics.