### PR TITLE
Add github metadata - CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+aws/ @ministryofjustice/laa-aws-infrastructure


### PR DESCRIPTION
Adding AWS Ops Team to be code reviewers for anything AWS related. This is to ensure our awareness and collaboration are taken into consideration when raising PRs that will affect the AWS Infrastructure.