### PR TITLE
Show number of cases in each category on dashboard

### DIFF
--- a/aws/application/monitoring_stack.template
+++ b/aws/application/monitoring_stack.template
@@ -170,7 +170,7 @@ Resources:
                 "type": "metric",
                 "x": 0,
                 "y": 0,
-                "width": 12,
+                "width": 24,
                 "height": 6,
                 "properties": {
                     "metrics": [
@@ -189,8 +189,24 @@ Resources:
             },
             {
                 "type": "metric",
+                "x": 0,
+                "y": 6,
+                "width": 12,
+                "height": 6,
+                "properties": {
+                    "metrics": [
+                        [ "nolasa", "reconciliation.tasks.max", "method", "reconcile", "class", "com.laa.nolasa.laanolasa.scheduler.OncePerDayScheduler", { "period": 3600, "stat": "Maximum" } ]
+                    ],
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "region": "${AWS::Region}",
+                    "title": "Time taken"
+                }
+            },
+            {
+                "type": "metric",
                 "x": 12,
-                "y": 0,
+                "y": 6,
                 "width": 12,
                 "height": 6,
                 "properties": {
@@ -205,7 +221,7 @@ Resources:
             {
               "type" : "metric",
               "x" : 0,
-              "y" : 6,
+              "y" : 12,
               "width" : 12,
               "height" : 6,
               "properties" : {
@@ -223,7 +239,7 @@ Resources:
             {
               "type" : "metric",
               "x" : 12,
-              "y" : 6,
+              "y" : 12,
               "width" : 12,
               "height" : 6,
               "properties" : {


### PR DESCRIPTION
There are now 5 metrics counting the outcome of NOLASA queries:

- there are no matches returned from libra
- there is 1 match
- there are multiple matches
- there are matches, but they have already been rejected by a case worker
- there was an error running the query (not sure how to test this one)

This PR adds them to a graph on the dashboard.

In cloudwatch, metrics have to be for a defined period of time, so each datapoint on the graph represents one hour. This matches how frequently we run the job on test.

I've also added the time taken to run the task, and updated the metric names as I've renamed them in the code.