### PR TITLE
Remove timeout attribute from app deployment

### DIFF
--- a/aws/application/app-main.template
+++ b/aws/application/app-main.template
@@ -99,7 +99,6 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: application_stack.template
-      TimeoutInMinutes: 20
       Parameters:
         pAppName: !Ref pAppName
         pAppEcsCluster:


### PR DESCRIPTION
Currently it fails to deploy in UAT. This is temporary change, it can be readded with appropriate value once we know how long it would take.