### PR TITLE
Setting the desired service task for ECS service count to 0

### DIFF
--- a/aws/application/application_stack.template
+++ b/aws/application/application_stack.template
@@ -64,7 +64,7 @@ Resources:
     Type: AWS::ECS::Service
     Properties:
       Cluster: !Ref pAppEcsCluster
-      DesiredCount: '1'
+      DesiredCount: '0'
       TaskDefinition: !Ref 'TaskDefinition'
       DeploymentConfiguration:
         MaximumPercent: 200


### PR DESCRIPTION
Currently nolasa fails to deploy to UAT. The issue was raised with AWS and they have suggested to change this parameter