### PR TITLE
Switch on cloudwatch metrics in other environments

### DIFF
--- a/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
@@ -13,7 +13,8 @@
     "pLibraEndPointURI" : "http://infox.aws.dev.legalservices.gov.uk/infoX/gateway",
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
-    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic"
+    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
+    "pCloudWatchExportEnabled": "true"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
@@ -13,7 +13,8 @@
     "pLibraEndPointURI" : "http://infox.aws.prd.legalservices.gov.uk/infoX/gateway",
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
-    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic"
+    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
+    "pCloudWatchExportEnabled": "true"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
@@ -13,7 +13,8 @@
     "pLibraEndPointURI" : "http://infox.aws.stg.legalservices.gov.uk/infoX/gateway",
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
-    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic"
+    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
+    "pCloudWatchExportEnabled": "true"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
@@ -13,7 +13,8 @@
     "pLibraEndPointURI" : "http://infox.aws.uat.legalservices.gov.uk/infoX/gateway",
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
-    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic"
+    "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
+    "pCloudWatchExportEnabled": "true"
   },
   "Tags" : {
     "business-unit" : "LAA",


### PR DESCRIPTION
This makes application metrics available in cloudwatch. Previously it was only enabled for test.