### PR TITLE
Removed namespace prefix and zone suffix from soap payload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,9 @@ dependencies {
     testCompile('org.springframework.boot:spring-boot-starter-test')
     compile 'com.amazonaws:aws-xray-recorder-sdk-spring:1.3.1'
     compile 'org.aspectj:aspectjrt:1.9.2'
-    compile(files(genJaxb.classesDir).builtBy(genJaxb))
+    compile(files(genJaxb.classesDir).builtBy(genJaxb))    
+    compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
+    compile 'com.sun.xml.bind:jaxb-core:2.2.11'
     jaxb "com.sun.xml.bind:jaxb-xjc:2.1.7"
 }
 

--- a/src/main/java/com/laa/nolasa/laanolasa/builder/LibraSearchRequestBuilder.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/builder/LibraSearchRequestBuilder.java
@@ -8,11 +8,13 @@ import uk.gov.justice._2013._11.magistrates.LibraSearchRequest;
 import uk.gov.justice._2013._11.magistrates.ObjectFactory;
 
 import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Optional;
 
@@ -43,6 +45,10 @@ public class LibraSearchRequestBuilder {
 
     XMLGregorianCalendar getGregorianCalendar(LocalDateTime date) throws DatatypeConfigurationException {
         GregorianCalendar gcal = GregorianCalendar.from(ZonedDateTime.of(date, ZoneId.systemDefault()));
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal);
+
+        XMLGregorianCalendar xmlCal = DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal);
+        xmlCal.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
+
+        return xmlCal;
     }
 }

--- a/src/main/java/com/laa/nolasa/laanolasa/service/ApplicationConfig.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/service/ApplicationConfig.java
@@ -2,6 +2,7 @@ package com.laa.nolasa.laanolasa.service;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +13,9 @@ import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.soap.SoapVersion;
 import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 public class ApplicationConfig {
@@ -29,6 +33,17 @@ public class ApplicationConfig {
   Jaxb2Marshaller jaxb2Marshaller() {
     Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
     jaxb2Marshaller.setContextPath("uk.gov.justice._2013._11.magistrates");
+    NamespacePrefixMapper mapper = new NamespacePrefixMapper() {
+      public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+        if ("http://www.justice.gov.uk/2013/11/magistrates".equals(namespaceUri) && !requirePrefix)
+          return "";
+        return "ns";
+      }
+    };
+    Map<String, Object> propertiesMap = new HashMap<>();
+    propertiesMap.put("jaxb.formatted.output", true);
+    propertiesMap.put("com.sun.xml.bind.namespacePrefixMapper", mapper);
+    jaxb2Marshaller.setMarshallerProperties(propertiesMap);
 
     return jaxb2Marshaller;
   }


### PR DESCRIPTION
On the first day of deployment of NOLASA to live we recieved Libra Response code: LIBRA_FAILED_EXCEPTION against all searches. Libra error code from INFOX is UNKOWN EXCEPTION which is not helpful.  In order to investigate the issue, compared the payloads of manual search against the auto search. The only diofference was in namespace usage and XML date zone includion. Not sure why LIBRA rejects these payloads. However, quick solution is to have the exactly same format.

Manual Search format:
```
<?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
   <env:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
      <wsa:To env:mustUnderstand="true">libra.gov.uk</wsa:To>
      <wsa:From>
         <wsa:Address>laa.gov.uk</wsa:Address>
      </wsa:From>
      <wsa:Action>search</wsa:Action>
      <wsa:MessageID>3d1dc0b8-cd64-4d21-adbf-fddcadaaeacb</wsa:MessageID>
   </env:Header>
   <env:Body>
      <LibraSearchRequest xmlns="http://www.justice.gov.uk/2013/11/magistrates">
         <criteria>
            <CJSAreaCode>30</CJSAreaCode>
            <Surname>HUTTON</Surname>
            <SearchType>0</SearchType>
            <DateOfHearing>2019-01-08</DateOfHearing>
            <SearchPattern>5</SearchPattern>
         </criteria>
      </LibraSearchRequest>
   </env:Body>
</env:Envelope>
```

Auto Search Format:
```
<?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
   <env:Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
      <wsa:To env:mustUnderstand="true">libra.gov.uk</wsa:To>
      <wsa:From>
         <wsa:Address>laa.gov.uk</wsa:Address>
      </wsa:From>
      <wsa:Action>search</wsa:Action>
      <wsa:MessageID>216d10f6-b368-4895-91ec-5f583d3e899e</wsa:MessageID>
   </env:Header>
   <env:Body>
      <ns2:LibraSearchRequest xmlns:ns2="http://www.justice.gov.uk/2013/11/magistrates">
         <ns2:criteria>
            <ns2:CJSAreaCode>22</ns2:CJSAreaCode>
            <ns2:Surname>COTTON</ns2:Surname>
            <ns2:SearchType>0</ns2:SearchType>
            <ns2:DateOfHearing>2018-12-11Z</ns2:DateOfHearing>
            <ns2:SearchPattern>5</ns2:SearchPattern>
         </ns2:criteria>
      </ns2:LibraSearchRequest>
   </env:Body>
</env:Envelope>
```

So two noticeable differences a) ns2:prefix in SOAP Body b) DateOfHearing have Z suffix.

This fix removes prefix ns2 and Z suffix from DateOfHEaring