### PR TITLE
Don't send metrics every minute

### DIFF
--- a/aws/application/app-main.template
+++ b/aws/application/app-main.template
@@ -82,6 +82,10 @@ Parameters:
         - true
         - false
     Description: Enable export of application metrics to Cloudwatch
+  pCloudWatchStep:
+    Type: String
+    Default: "10m"
+    Description: How often metrics are exported to Cloudwatch
 
 Resources:
   AppInfrastructureTemplate:
@@ -115,6 +119,7 @@ Resources:
         pDataSourcePwd: !Ref pDataSourcePwd
         pDataSourceUrl: !Ref pDataSourceUrl
         pCloudWatchExportEnabled: !Ref pCloudWatchExportEnabled
+        pCloudWatchStep: !Ref pCloudWatchStep
 
   MonitoringTemplate:
     Type: AWS::CloudFormation::Stack

--- a/aws/application/application_stack.template
+++ b/aws/application/application_stack.template
@@ -45,6 +45,10 @@ Parameters:
         - true
         - false
     Description: Enable export of application metrics to Cloudwatch
+  pCloudWatchStep:
+    Type: String
+    Default: "10m"
+    Description: How often metrics are exported to Cloudwatch
 
 Resources:
 
@@ -150,6 +154,8 @@ Resources:
               Value: !Ref pLibraEndPointURI
             - Name: CLOUDWATCH_EXPORT_ENABLED
               Value: !Ref pCloudWatchExportEnabled
+            - Name: CLOUDWATCH_STEP
+              Value: !Ref pCloudWatchStep
 
   CloudwatchLogsGroupECS:
     Type: AWS::Logs::LogGroup

--- a/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
@@ -14,7 +14,8 @@
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
     "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
-    "pCloudWatchExportEnabled": "true"
+    "pCloudWatchExportEnabled": "true",
+    "pCloudWatchExportStep": "1h"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
@@ -14,7 +14,8 @@
     "pSev5SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev5SnsTopic",
     "pSev2SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev2SnsTopic",
     "pSev1SnsTopicArn" : "arn:aws:sns:eu-west-2:902837325998:Sev1SnsTopic",
-    "pCloudWatchExportEnabled": "true"
+    "pCloudWatchExportEnabled": "true",
+    "pCloudWatchExportStep": "1h"
   },
   "Tags" : {
     "business-unit" : "LAA",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - APP_DRY_RUN_MODE=true
       - LIBRA_ENDPOINTURI=http://host.docker.internal:8080/infoX/gateway
       - CLOUDWATCH_EXPORT_ENABLED=false
+      - CLOUDWATCH_EXPORT_STEP=10m
     ports:
     - 8081:8080
     - 8001:8000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ management:
         enabled: ${CLOUDWATCH_EXPORT_ENABLED}
         namespace: nolasa
         batch-size: 20
-        step: 10m
+        step: ${CLOUDWATCH_EXPORT_STEP}
 
 cloud:
   aws:


### PR DESCRIPTION
By default, metrics are exported to cloudwatch every minute,
but the application only does anything when the scheduler runs, so this
results in a lot of unneccessary requests and clutters up the logs.

I was originally planning to set this to hourly, but I think that will
be a bit annoying because if we're running NOLASA on the test
environment, it could take up to 2 hours before we see anything on the
dashboard.

I've made it every 10m instead.

This doesn't change what the dashboard displays, because the dashboard
already summarises what happened each hour, due to this configuration:

```
{ "stat": "Sum", "period": 3600 }
```