### PR TITLE
LASB-110: 'Not found' is not correct

### DIFF
--- a/aws/application/monitoring_stack.template
+++ b/aws/application/monitoring_stack.template
@@ -178,6 +178,7 @@ Resources:
                         [ ".", "result.no_match", ".", ".", { "stat": "Sum", "period": 3600 } ],
                         [ ".", "result.single_match", ".", ".", { "stat": "Sum", "period": 3600 } ],
                         [ ".", "result.multi_match", ".", ".", { "stat": "Sum", "period": 3600 } ],
+                        [ ".", "result.over_15_match", ".", ".", { "stat": "Sum", "period": 3600 } ],
                         [ ".", "result.already_rejected", ".", ".", { "stat": "Sum", "period": 3600 } ]
                     ],
                     "view": "timeSeries",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - DATASOURCE_USERNAME=mla
       - DATASOURCE_PASSWORD=dietc0ke
       - APP_CRON_STRING=0 * * ? * *
-      - APP_DRY_RUN_MODE=true
+      - APP_DRY_RUN_MODE=false
       - LIBRA_ENDPOINTURI=http://host.docker.internal:8080/infoX/gateway
       - CLOUDWATCH_EXPORT_ENABLED=false
     ports:

--- a/src/main/java/com/laa/nolasa/laanolasa/builder/InfoxSearchResultBuilder.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/builder/InfoxSearchResultBuilder.java
@@ -10,8 +10,6 @@ import uk.gov.justice._2013._11.magistrates.LibraSearchResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.laa.nolasa.laanolasa.dto.InfoXSearchResult.MAX_LIBRA_RECORDS;
-
 @Component
 @Slf4j
 public class InfoxSearchResultBuilder {
@@ -20,13 +18,11 @@ public class InfoxSearchResultBuilder {
 
         InfoxStatus infoxStatus = InfoxStatus.fromString(libraSearchResponse.getAckResponse().getException().getERRORCODE());
 
-        log.info("Libra Response code:{}", infoxStatus);
+        log.info("Libra Response :{}, code: {}", infoxStatus, libraSearchResponse.getAckResponse().getException().getERRORCODE());
         switch (infoxStatus) {
             case LIBRA_GREATER_THAN_15_CODE:
-                log.info("{} matches found by Libra, only storing {}", libraSearchResponse.getSearchResultItem().size(), MAX_LIBRA_RECORDS);
-                return getInfoXSearchResult(libraSearchResponse);
             case LIBRA_SUCCESS_CODE:
-                log.info("{} matches found by Libra", libraSearchResponse.getSearchResultItem().size());
+            case LIBRA_NO_MATCH_FOUND:
                 return getInfoXSearchResult(libraSearchResponse);
             case LIBRA_FAILED_EXCEPTION:
             case LIBRA_INVALID_CODE:
@@ -38,7 +34,6 @@ public class InfoxSearchResultBuilder {
     InfoXSearchResult getInfoXSearchResult(LibraSearchResponse libraSearchResponse) {
 
         List<Long> results  = libraSearchResponse.getSearchResultItem().stream()
-                .limit(MAX_LIBRA_RECORDS)
                 .map(rs -> rs.getCaseResult().stream()
                         .findFirst().get()
                         .getCaseDetail()

--- a/src/main/java/com/laa/nolasa/laanolasa/builder/LibraSearchRequestBuilder.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/builder/LibraSearchRequestBuilder.java
@@ -14,7 +14,6 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Optional;
 

--- a/src/main/java/com/laa/nolasa/laanolasa/common/InfoxStatus.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/common/InfoxStatus.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 public enum InfoxStatus {
     LIBRA_SUCCESS_CODE("1"),
     LIBRA_GREATER_THAN_15_CODE("100100"),
+    LIBRA_NO_MATCH_FOUND("100000"),
     LIBRA_FAILED_EXCEPTION("999999"),
     LIBRA_INVALID_CODE("invalid");
 

--- a/src/main/java/com/laa/nolasa/laanolasa/dto/InfoXSearchResult.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/dto/InfoXSearchResult.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Getter
 public class InfoXSearchResult {
-    public static final int MAX_LIBRA_RECORDS = 15;
     private List<Long> libraIDs  = new ArrayList<>();
     private final InfoXSearchStatus status;
 }

--- a/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/service/ReconciliationService.java
@@ -68,7 +68,6 @@ public class ReconciliationService {
                 log.info("Results were previously rejected, no changes are detected in libra IDs corresponding to the MAAT ID: {} ", maatId);
                 return ReconciliationResult.MATCHES_ALREADY_REJECTED;
             } else {
-                log.info("about to update");
                 updateNol(entity, infoXSearchResult);
                 return ReconciliationResult.fromCount(numberOfResults);
             }

--- a/src/main/java/com/laa/nolasa/laanolasa/util/MetricHandler.java
+++ b/src/main/java/com/laa/nolasa/laanolasa/util/MetricHandler.java
@@ -11,6 +11,7 @@ public class MetricHandler {
     private Counter singleMatchQueries;
     private Counter multiMatchQueries;
     private Counter noMatchQueries;
+    private Counter over15MatchQueries;
     private Counter errorQueries;
     private Counter alreadyRejectedQueries;
     private DistributionSummary numberOfResults;
@@ -26,6 +27,10 @@ public class MetricHandler {
 
         this.noMatchQueries = Counter.builder("result.no_match")
                 .description("Number of queries returning no matches")
+                .register(registry);
+
+        this.over15MatchQueries = Counter.builder("result.over_15_match")
+                .description("Number of queries returning over 15 matches")
                 .register(registry);
 
         this.errorQueries = Counter.builder("result.error")
@@ -44,6 +49,9 @@ public class MetricHandler {
 
     public void recordReconciliationResult(ReconciliationResult result) {
         switch (result) {
+            case OVER_15_MATCHES:
+                this.over15MatchQueries.increment();
+                break;
             case ERROR:
                 this.errorQueries.increment();
                 break;

--- a/src/test/java/com/laa/nolasa/laanolasa/builder/InfoxSearchResultBuilderTest.java
+++ b/src/test/java/com/laa/nolasa/laanolasa/builder/InfoxSearchResultBuilderTest.java
@@ -1,5 +1,7 @@
 package com.laa.nolasa.laanolasa.builder;
 
+import com.laa.nolasa.laanolasa.common.InfoxStatus;
+import com.laa.nolasa.laanolasa.common.ReconciliationResult;
 import com.laa.nolasa.laanolasa.dto.InfoXSearchResult;
 import com.laa.nolasa.laanolasa.dto.InfoXSearchStatus;
 import org.junit.Before;
@@ -19,33 +21,33 @@ public class InfoxSearchResultBuilderTest {
     }
 
     @Test
-    public void shouldBuildInfoXSearchResultSucceedWhenStatusIs100100() {
+    public void shouldBuildInfoXSearchResultSucceedWhenStatusIsGreaterThan15Code() {
         LibraSearchResponse libraSearchResponse = getLibraSearchResponse();
-        libraSearchResponse.getAckResponse().getException().setERRORCODE("100100");
+        libraSearchResponse.getAckResponse().getException().setERRORCODE(InfoxStatus.LIBRA_GREATER_THAN_15_CODE.getCode());
         InfoXSearchResult infoXSearchResult = infoxSearchResultBuilder.buildInfoXSearchResult(libraSearchResponse);
         assertEquals(InfoXSearchStatus.SUCCESS, infoXSearchResult.getStatus());
     }
     @Test
-    public void shouldBuildInfoXSearchResultSucceedWhenStatusIs1() {
+    public void shouldBuildInfoXSearchResultSucceedWhenStatusIsSuccessCode() {
         LibraSearchResponse libraSearchResponse = getLibraSearchResponse();
-        libraSearchResponse.getAckResponse().getException().setERRORCODE("1");
+        libraSearchResponse.getAckResponse().getException().setERRORCODE(InfoxStatus.LIBRA_SUCCESS_CODE.getCode());
         InfoXSearchResult infoXSearchResult = infoxSearchResultBuilder.buildInfoXSearchResult(libraSearchResponse);
         assertEquals(InfoXSearchStatus.SUCCESS, infoXSearchResult.getStatus());
     }
     @Test
-    public void shouldBuildInfoXSearchResultFailWhenStatusIs999999() {
+    public void shouldBuildInfoXSearchResultFailWhenStatusIsLibraFailedException() {
         LibraSearchResponse libraSearchResponse = getLibraSearchResponse();
-        libraSearchResponse.getAckResponse().getException().setERRORCODE("999999");
+        libraSearchResponse.getAckResponse().getException().setERRORCODE(InfoxStatus.LIBRA_FAILED_EXCEPTION.getCode());
         InfoXSearchResult infoXSearchResult = infoxSearchResultBuilder.buildInfoXSearchResult(libraSearchResponse);
         assertEquals(InfoXSearchStatus.FAILURE, infoXSearchResult.getStatus());
     }
 
     @Test
-    public void shouldBuildInfoXSearchResultFailWhenStatusIs100000() {
+    public void shouldBuildInfoXSearchResultFailWhenStatusIsNoMatchFound() {
         LibraSearchResponse libraSearchResponse = getLibraSearchResponse();
-        libraSearchResponse.getAckResponse().getException().setERRORCODE("100000");
+        libraSearchResponse.getAckResponse().getException().setERRORCODE(InfoxStatus.LIBRA_NO_MATCH_FOUND.getCode());
         InfoXSearchResult infoXSearchResult = infoxSearchResultBuilder.buildInfoXSearchResult(libraSearchResponse);
-        assertEquals(InfoXSearchStatus.FAILURE, infoXSearchResult.getStatus());
+        assertEquals(InfoXSearchStatus.SUCCESS, infoXSearchResult.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Metrics was reporting counts for errors instead of no match found, so fixed the logic to correctly pass the counts based on status returned.

Removed the logic of limiting the result set to 15. After normalizing the database there is no restrictions on how many search result we can save. However, as the MLRA user interface only shows 15 results, so it is good idea to provide this figure in metrics. So added results.over_15_count to metrics