### PR TITLE
Correct typo in environment variable name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - APP_DRY_RUN_MODE=true
       - LIBRA_ENDPOINTURI=http://host.docker.internal:8080/infoX/gateway
       - CLOUDWATCH_EXPORT_ENABLED=false
-      - CLOUDWATCH_EXPORT_STEP=10m
+      - CLOUDWATCH_STEP=10m
     ports:
     - 8081:8080
     - 8001:8000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ management:
         enabled: ${CLOUDWATCH_EXPORT_ENABLED}
         namespace: nolasa
         batch-size: 20
-        step: ${CLOUDWATCH_EXPORT_STEP}
+        step: ${CLOUDWATCH_STEP}
 
 cloud:
   aws:


### PR DESCRIPTION
Followup to https://github.com/ministryofjustice/laa-nolasa/pull/52

The environment variable name didn't match between the Cloud formation template and application.yml.