### PR TITLE
Revert "Add a config file so dependabot can automatically monitor for dependency updates"

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - directory: "/"
-    package_manager: "java:gradle"
-    update_schedule: "daily"


### PR DESCRIPTION
Reverts ministryofjustice/laa-nolasa#58

We've hit our limit for private repos in dependabot, so we can't use this until we either open up the repo or change our plan.

😢 