### PR TITLE
Fixing 'trustAnchors parameter must be non-e,pty' issue with jdk 11

### DIFF
--- a/buildspec-lz.yml
+++ b/buildspec-lz.yml
@@ -5,9 +5,8 @@ phases:
       - apt-get update -y
       - add-apt-repository ppa:openjdk-r/ppa
       - apt-get update -y
+      - apt-get install -y software-properties-common openjdk-8-jdk zip
       - apt-get install -y software-properties-common openjdk-11-jdk zip
-#      - add-apt-repository ppa:openjdk-r/ppa
-#      - apt-get install -y openjdk-8-jdk
       - update-ca-certificates -f
   pre_build:
     commands:


### PR DESCRIPTION
Recieved the following error at build phase of code pipleline:

[Container] 2019/03/19 11:55:09 Running command chmod +x ./gradlew && ./gradlew build
Downloading https://services.gradle.org/distributions/gradle-5.2.1-all.zip
 Exception in thread "main" javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty

Got the follwoing solution by googling on the issue:
https://askubuntu.com/a/971457

So installing jdk 8 before jdk 11