### PR TITLE
Cost analysis of the application by the Webops team shows overprovisi…

### DIFF
--- a/aws/application/application_stack.template
+++ b/aws/application/application_stack.template
@@ -177,7 +177,7 @@ Resources:
           Cpu: '1024'
           Essential: 'true'
           Image: !Join [':', [!Ref pECSRepositoryURI, !Ref pDockerImageTag ]]
-          Memory: '900'
+          Memory: '450'
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/aws/application/application_stack.template
+++ b/aws/application/application_stack.template
@@ -50,6 +50,16 @@ Parameters:
     Default: "10m"
     Description: How often metrics are exported to Cloudwatch
 
+Conditions:
+  cCreateNonprodResources:
+    !Or
+      - !Equals [ !Ref pEnvironment, "development" ]
+      - !Equals [ !Ref pEnvironment, "test" ]
+      - !Equals [ !Ref pEnvironment, "uat" ]
+      - !Equals [ !Ref pEnvironment, "staging" ]
+
+  cProdTaskDefinition: !Equals [ !Ref pEnvironment, "production" ]
+
 Resources:
 
 ################################################################################
@@ -69,7 +79,7 @@ Resources:
     Properties:
       Cluster: !Ref pAppEcsCluster
       DesiredCount: '1'
-      TaskDefinition: !Ref 'TaskDefinition'
+      TaskDefinition: !If [cProdTaskDefinition, !Ref TaskDefinition, !Ref NonProdTaskDefinition]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 0
@@ -157,6 +167,41 @@ Resources:
             - Name: CLOUDWATCH_STEP
               Value: !Ref pCloudWatchStep
 
+  NonProdTaskDefinition:
+    Condition: cCreateNonprodResources
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Join [ '', [ !Ref pAppName, '-app' ] ]
+      ContainerDefinitions:
+        - Name: !Ref pAppName
+          Cpu: '1024'
+          Essential: 'true'
+          Image: !Join [':', [!Ref pECSRepositoryURI, !Ref pDockerImageTag ]]
+          Memory: '900'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroupECS'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: !Sub '${pAppName}-app'
+          Environment:
+            - Name: DATASOURCE_URL
+              Value: !Ref pDataSourceUrl
+            - Name: DATASOURCE_USERNAME
+              Value: !Ref pDataSourceUname
+            - Name: DATASOURCE_PASSWORD
+              Value: !GetAtt DataSourcePwd2.Value
+            - Name: APP_CRON_STRING
+              Value: !Ref pAppCronString
+            - Name: APP_DRY_RUN_MODE
+              Value: !Ref pAppDryRunMode
+            - Name: LIBRA_ENDPOINTURI
+              Value: !Ref pLibraEndPointURI
+            - Name: CLOUDWATCH_EXPORT_ENABLED
+              Value: !Ref pCloudWatchExportEnabled
+            - Name: CLOUDWATCH_STEP
+              Value: !Ref pCloudWatchStep
+
   CloudwatchLogsGroupECS:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -199,4 +244,4 @@ Outputs:
   EcsService:
     Value: !Ref EcsService
   taskdef:
-    Value: !Ref 'TaskDefinition'
+    Value: !If [cProdTaskDefinition, !Ref TaskDefinition, !Ref NonProdTaskDefinition]

--- a/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
@@ -4,7 +4,7 @@
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
     "pEcsAmiId" : "ami-3622cf51",
-    "pEc2InstanceType" : "t2.small",
+    "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "development-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.dev.legalservices.gov.uk:1521:MAATDB",
     "pDataSourceUname" : "MLA",

--- a/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
@@ -4,7 +4,7 @@
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
     "pEcsAmiId" : "ami-3622cf51",
-    "pEc2InstanceType" : "t2.small",
+    "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "staging-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.stg.legalservices.gov.uk:1521:MAATDB",
     "pDataSourceUname" : "MLA",

--- a/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
@@ -4,7 +4,7 @@
     "pECSRepositoryURI": "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag": "latest",
     "pEcsAmiId": "ami-3622cf51",
-    "pEc2InstanceType": "t2.small",
+    "pEc2InstanceType": "t3a.micro",
     "pSshKeyName": "test-general",
     "pDataSourceUrl": "jdbc:oracle:thin:@rds.maat.aws.tst.legalservices.gov.uk:1521:MAATDB",
     "pDataSourceUname": "MLA",

--- a/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
@@ -4,7 +4,7 @@
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
     "pEcsAmiId" : "ami-3622cf51",
-    "pEc2InstanceType" : "t2.small",
+    "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "uat-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.uat.legalservices.gov.uk:1521:MAATDB",
     "pDataSourceUname" : "MLA",


### PR DESCRIPTION
…oning of memory

allocation for the ECS Task Definition. The latter requires a larger ec2 instance than
necessary which increases costs. The change implemented reduces Task Definition memory
and reduces the ec2 instance size in Dev, Test, UAT, and Staging only.

## What

[LAWS-747](https://dsdmoj.atlassian.net/browse/LAWS-747)

Cost analysis of the application by the Webops team shows over-provisioning allocation for the ECS Task Definition. The latter requires a larger ec2 instance than necessary which increases costs. The change implemented reduces Task Definition memory and reduces the ec2 instance size in Dev, Test, UAT, and Staging only.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
