### PR TITLE
Fix environment parameter in main template as it is used in the child…

### DIFF
--- a/aws/application/app-main.template
+++ b/aws/application/app-main.template
@@ -86,6 +86,9 @@ Parameters:
     Type: String
     Default: "10m"
     Description: How often metrics are exported to Cloudwatch
+  pEnvironment:
+    Type: String
+    Default: ''
 
 Resources:
   AppInfrastructureTemplate:
@@ -120,6 +123,7 @@ Resources:
         pDataSourceUrl: !Ref pDataSourceUrl
         pCloudWatchExportEnabled: !Ref pCloudWatchExportEnabled
         pCloudWatchStep: !Ref pCloudWatchStep
+        pEnvironment: !Ref pEnvironment
 
   MonitoringTemplate:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
… stack

## What

Fix environment parameter in main template as it is used in the child stack. This is to implement ECS and EC2 right-sizing in non-production environments only.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase master`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against master and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
