### PR TITLE
[LAWS-2152] Upgrade AMI and add SSM managed policy

### DIFF
--- a/aws/application/infrastructure_stack.template
+++ b/aws/application/infrastructure_stack.template
@@ -69,6 +69,8 @@ Resources:
             Service: [ec2.amazonaws.com]
           Action: ['sts:AssumeRole']
       Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: app-ecs-service
         PolicyDocument:
@@ -155,6 +157,9 @@ Resources:
 
   AppECSAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy:
+      AutoScalingReplacingUpdate:
+        WillReplace: True
     Properties:
       DesiredCapacity: 2
       LaunchConfigurationName: !Ref AppEc2LaunchConfig

--- a/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/development-laa-not-on-libra-autosearch-pipeline.json
@@ -3,7 +3,7 @@
     "pAppName" : "laa-not-on-libra-autosearch",
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
-    "pEcsAmiId" : "ami-3622cf51",
+    "pEcsAmiId" : "ami-0631049bf050d0d46",
     "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "development-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.dev.legalservices.gov.uk:1521:MAATDB",

--- a/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/production-laa-not-on-libra-autosearch-pipeline.json
@@ -3,7 +3,7 @@
     "pAppName" : "laa-not-on-libra-autosearch",
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
-    "pEcsAmiId" : "ami-3622cf51",
+    "pEcsAmiId" : "ami-0631049bf050d0d46",
     "pEc2InstanceType" : "t2.small",
     "pSshKeyName" : "production-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.prd.legalservices.gov.uk:1521:MAATDB",

--- a/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/staging-laa-not-on-libra-autosearch-pipeline.json
@@ -3,7 +3,7 @@
     "pAppName" : "laa-not-on-libra-autosearch",
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
-    "pEcsAmiId" : "ami-3622cf51",
+    "pEcsAmiId" : "ami-0631049bf050d0d46",
     "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "staging-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.stg.legalservices.gov.uk:1521:MAATDB",

--- a/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/test-laa-not-on-libra-autosearch-pipeline.json
@@ -3,7 +3,7 @@
     "pAppName": "laa-not-on-libra-autosearch",
     "pECSRepositoryURI": "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag": "latest",
-    "pEcsAmiId": "ami-3622cf51",
+    "pEcsAmiId": "ami-0631049bf050d0d46",
     "pEc2InstanceType": "t3a.micro",
     "pSshKeyName": "test-general",
     "pDataSourceUrl": "jdbc:oracle:thin:@rds.maat.aws.tst.legalservices.gov.uk:1521:MAATDB",

--- a/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
+++ b/aws/application/parameters/uat-laa-not-on-libra-autosearch-pipeline.json
@@ -3,7 +3,7 @@
     "pAppName" : "laa-not-on-libra-autosearch",
     "pECSRepositoryURI" : "902837325998.dkr.ecr.eu-west-2.amazonaws.com/laa-not-on-libra-autosearch",
     "pDockerImageTag" : "latest",
-    "pEcsAmiId" : "ami-3622cf51",
+    "pEcsAmiId" : "ami-0631049bf050d0d46",
     "pEc2InstanceType" : "t3a.micro",
     "pSshKeyName" : "uat-general",
     "pDataSourceUrl" : "jdbc:oracle:thin:@rds.maat.aws.uat.legalservices.gov.uk:1521:MAATDB",


### PR DESCRIPTION
There is a requirement to enable SSM management on our instances.
This PR upgrades the underlying AMI to the latest version and gives the EC2 instances permissions to communicate with SSM (AWS Systems Manager)

The AMI upgrade is required for SSM installation - but has zero affect on the docker containers hosting the application