### PR TITLE
Enable reconciliation scheduler in prod

### DIFF
--- a/helm_deploy/not-on-libra-auto-search-application/values_prd.yaml
+++ b/helm_deploy/not-on-libra-auto-search-application/values_prd.yaml
@@ -25,7 +25,7 @@ nolasa:
   cronSchedule: "0 0 18 * * SUN-THU" # Cron schedule for when the matching job gets ran
   libraEndpointUri: "https://infox.service.justice.gov.uk/infoX/gateway"
   reconciliationSchedulerTask:
-    enabled: false
+    enabled: true
 
   sentry:
     sampleRate: 1.0


### PR DESCRIPTION
This PR enables the reconciliation scheduler in prod. It used to be enabled by default as part of the OncePerDayScheduler class, however an annotation has recently been added which makes this scheduler conditional on an `enabled` property in configuration being set to `true`.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4277)
